### PR TITLE
Harden ci-autopilot portfolio docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ci-autopilot
 
-AI-powered CI autopilot — detects GitHub Actions failures and autonomously dispatches repairs via a Python agent
+AI-powered CI autopilot worker/runtime - detects GitHub Actions failures and dispatches repairs via a Python agent
 
 [![CI](https://github.com/Coding-Autopilot-System/ci-autopilot/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/Coding-Autopilot-System/ci-autopilot/actions/workflows/ci.yml)
 [![Python 3.12](https://img.shields.io/badge/python-3.12-blue.svg)](https://www.python.org/)
@@ -8,9 +8,15 @@ AI-powered CI autopilot — detects GitHub Actions failures and autonomously dis
 
 ## Overview
 
-ci-autopilot is an AI-powered CI repair agent that monitors GitHub Actions workflows, detects failures, triages them via an issue queue, and dispatches autonomous repairs using a Python agent backed by Codex. It runs on a self-hosted runner and coordinates the full lifecycle from failure detection to merged fix.
+`ci-autopilot` packages the worker/runtime side of the platform. It monitors GitHub Actions workflows, detects failures, triages them via an issue queue, and dispatches autonomous repairs using a Python agent backed by Codex. It runs on a self-hosted runner and provides the execution path from queued repair task to proposed fix.
 
 The agent (`agent/poll_once.py`) is a Python 3.12 stdlib-only program that polls the issue queue, picks up queued repair tasks, and dispatches them to the Codex repair pipeline. No external dependencies are required.
+
+## Repo boundary
+
+- `autopilot-core` is the control plane for org-level scheduling, rollout, and PR governance.
+- `ci-autopilot` is the worker/runtime implementation for runner execution, queue polling, and repair dispatch.
+- `autopilot-demo` is the demonstration target used to show the runtime and control plane working together.
 
 ## Architecture
 
@@ -25,12 +31,19 @@ flowchart LR
 
 **Core components:**
 
-- **autopilot-failure-intake.yml** — Intake workflow triggered on `workflow_run` failure events; creates a queued issue
-- **autopilot-create-issue.yml** — Creates GitHub issues via `actions/github-script` when monitored workflows fail
-- **fixer.yml** — Main CI autopilot; runs `agent/poll_once.py` on the self-hosted Windows runner
-- **agent/poll_once.py** — Python 3.12 stdlib agent; polls the issue queue and dispatches repairs
-- **runner-smoke-test.yml** — Smoke tests the self-hosted runner on demand
-- **runner-health.yml** — Manual runner health check (dispatch only)
+- **autopilot-failure-intake.yml** - Intake workflow triggered on `workflow_run` failure events; creates a queued issue
+- **autopilot-create-issue.yml** - Creates GitHub issues via `actions/github-script` when monitored workflows fail
+- **fixer.yml** - Main CI autopilot; runs `agent/poll_once.py` on the self-hosted Windows runner
+- **agent/poll_once.py** - Python 3.12 stdlib agent; polls the issue queue and dispatches repairs
+- **runner-smoke-test.yml** - Smoke tests the self-hosted runner on demand
+- **runner-health.yml** - Manual runner health check (dispatch only)
+
+## Enterprise proof points
+
+- Deliberately small runtime surface: Python 3.12 stdlib-only agent for easier audit and rebuild.
+- Clear separation of concerns: issue intake and governance stay in the control plane; repair execution stays on the worker.
+- Self-hosted runner model supports enterprise network boundaries, managed toolchains, and least-privilege token handling.
+- Queue-driven processing creates an auditable handoff between CI failure detection and agent action.
 
 ## Quick Start
 
@@ -42,6 +55,12 @@ python -m agent.poll_once
 
 For full runner registration, service setup, and local development instructions see the [Setup Guide](https://github.com/Coding-Autopilot-System/ci-autopilot/wiki/Setup-Guide) wiki page.
 
+## Runbook path
+
+1. Read [docs/control-plane.md](docs/control-plane.md) for the issue-queue contract with `autopilot-core`.
+2. Use [docs/runner-setup.md](docs/runner-setup.md) to provision the worker host.
+3. Use [docs/operations.md](docs/operations.md) and [docs/troubleshooting.md](docs/troubleshooting.md) for day-2 support.
+
 ## Documentation
 
 | Source | Description |
@@ -51,10 +70,11 @@ For full runner registration, service setup, and local development instructions 
 | [docs/operations.md](docs/operations.md) | Day-2 operations runbook |
 | [docs/security.md](docs/security.md) | Security posture and access model |
 | [docs/control-plane.md](docs/control-plane.md) | Failure intake and issue control plane |
+| [docs/troubleshooting.md](docs/troubleshooting.md) | Lightweight troubleshooting guide |
 | [GitHub Pages](https://coding-autopilot-system.github.io/ci-autopilot/) | Professional docs landing page |
 
 **Wiki:** [Home](https://github.com/Coding-Autopilot-System/ci-autopilot/wiki/Home) | [Setup Guide](https://github.com/Coding-Autopilot-System/ci-autopilot/wiki/Setup-Guide) | [Architecture](https://github.com/Coding-Autopilot-System/ci-autopilot/wiki/Architecture) | [Configuration Reference](https://github.com/Coding-Autopilot-System/ci-autopilot/wiki/Configuration-Reference)
 
 ## Ecosystem
 
-Part of the [Coding-Autopilot-System](https://github.com/Coding-Autopilot-System) ecosystem: [gsd-orchestrator](https://github.com/Coding-Autopilot-System/gsd-orchestrator) | [Promptimprover](https://github.com/Coding-Autopilot-System/Promptimprover) | [autogen](https://github.com/Coding-Autopilot-System/autogen)
+Part of the [Coding-Autopilot-System](https://github.com/Coding-Autopilot-System) ecosystem alongside the adjacent autopilot repos: [autopilot-core](https://github.com/Coding-Autopilot-System/autopilot-core) | [autopilot-demo](https://github.com/Coding-Autopilot-System/autopilot-demo)

--- a/memory/examples/20260610_ci-autopilot_boundary-readme.md
+++ b/memory/examples/20260610_ci-autopilot_boundary-readme.md
@@ -1,0 +1,8 @@
+# 20260610_ci-autopilot_boundary-readme
+
+Issue Description: README overlapped with neighboring repos and undersold the worker/runtime role.
+State: It was not explicit enough that this repo is the runner-side execution path.
+Action: Added repo boundary language, enterprise proof points, and a short runbook path in `README.md`.
+Result: The repo now reads as the worker/runtime implementation instead of a generic platform overview.
+Diff Patch: Updated `README.md` only.
+Rationale: Portfolio readers need a fast distinction between governance/control plane and runner-hosted execution.


### PR DESCRIPTION
## Summary
- harden portfolio positioning in CI-focused documentation
- improve documentation clarity around the repo's value and usage
- tighten framing and wording without changing automation behavior