### PR TITLE
chore: harden repository governance

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 * @Coding-Autopilot-System/core
+/.github/         @Coding-Autopilot-System/core

--- a/.github/workflows/autopilot-create-issue.yml
+++ b/.github/workflows/autopilot-create-issue.yml
@@ -15,6 +15,7 @@ jobs:
   create-issue:
     if: ${{ github.event.workflow_run.conclusion == 'failure' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Create or update issue
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7

--- a/.github/workflows/autopilot-failure-intake.yml
+++ b/.github/workflows/autopilot-failure-intake.yml
@@ -14,6 +14,7 @@ jobs:
   create-issue:
     if: ${{ github.event.workflow_run.conclusion == 'failure' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     env:
       GH_TOKEN: ${{ github.token }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,13 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,10 +4,14 @@ on:
     branches: [ "main", "master" ]
   pull_request:
     branches: [ "main", "master" ]
+permissions:
+  contents: read
+
 jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -14,6 +14,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -29,6 +30,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs: build
     steps:
       - name: Deploy to GitHub Pages

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -3,9 +3,14 @@ on:
   pull_request:
     types: ['opened', 'edited', 'reopened', 'synchronize']
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   main:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: amannn/action-semantic-pull-request@v5
         env:

--- a/.github/workflows/runner-health.yml
+++ b/.github/workflows/runner-health.yml
@@ -13,6 +13,7 @@ permissions:
 jobs:
   check-runner:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     env:
       GH_TOKEN: ${{ secrets.RUNNER_PAT || github.token }}
       RUNNER_NAME: MyLocalPC

--- a/.github/workflows/runner-smoke-test.yml
+++ b/.github/workflows/runner-smoke-test.yml
@@ -3,6 +3,9 @@ name: Runner Smoke Test
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   smoke-test:
     runs-on: [self-hosted, Windows]

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -3,9 +3,15 @@ on:
   schedule:
     - cron: '30 1 * * *'
 
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
 jobs:
   stale:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/stale@v8
         with:


### PR DESCRIPTION
﻿## Summary
This PR applies the v1.1 portfolio-hardening slice for ci-autopilot and reduces workflow or runtime risk without broad refactoring.

## Changes
- Apply the scoped branch changes and preserve existing repository behavior
- Add or tighten verification where this repository participates in the CAS portfolio contract

## Why
Close evidence-backed CI, governance, contract-drift, or diagnostic gaps before the Shared AI Engineering OS milestone begins.

## Validation
- Existing branch commit reviewed for scoped governance and workflow changes; remote checks required.

## Risks
Self-hosted workflow permissions deserve reviewer attention.

## Related
CAS Portfolio Hardening v1.1.

## Reviewer notes
Start with the workflow permission/timeout diff and any contract or exception-boundary tests.
