### PR TITLE
ci: pin remaining actions to commit SHAs, add coverage regression gate, review runner token scope

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,5 +22,7 @@ jobs:
         run: python -m py_compile agent/poll_once.py
       - name: Import check
         run: python -c "import agent.poll_once"
+      - name: Install dependencies
+        run: pip install -r requirements.txt
       - name: Unit tests
-        run: python -m unittest discover -v
+        run: pytest --cov=agent --cov-report=term-missing --cov-fail-under=90 tests/

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,12 +22,12 @@ jobs:
         language: [ 'python' ]
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v7
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
       with:
         languages: ${{ matrix.language }}
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v4
+      uses: github/codeql-action/autobuild@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -16,13 +16,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: 3.x
       - run: pip install mkdocs-material
       - run: mkdocs build
-      - uses: actions/upload-pages-artifact@v5
+      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: ./site
   deploy:
@@ -35,4 +35,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -12,6 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: amannn/action-semantic-pull-request@v6
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/stale@v10
+      - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10.3.0
         with:
           days-before-stale: 60
           days-before-close: 7

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__/
 *.py[cod]
 .venv/
 logs/
+.coverage

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 # Base requirements for CI Autopilot
+pytest-cov


### PR DESCRIPTION
## Summary

Closes out ci-autopilot's remaining supply-chain gaps (S1) and the P3 coverage-gate backlog item, per Phase 31 wave 2 plan 31-05 (REQ-1.4.10).

- **SHA-pin the 4 remaining unpinned workflow files** (`codeql.yml`, `pages.yml`, `pr-lint.yml`, `stale.yml`). All third-party `uses:` refs now pinned to a 40-char commit SHA with a trailing `# vX.Y.Z` comment, resolved via `gh api repos/<owner>/<action>/commits/<tag>` against the tag currently in each file (`checkout@v7`, `codeql-action/{init,autobuild,analyze}@v4`, `setup-python@v6`, `upload-pages-artifact@v5`, `deploy-pages@v5`, `action-semantic-pull-request@v6`, `stale@v10`). `ci.yml`, `fixer.yml`, `runner-health.yml`, `autopilot-create-issue.yml`, `autopilot-failure-intake.yml`, `runner-smoke-test.yml` were already fully pinned and untouched by this change.
- **Coverage regression gate (P3):** `ci.yml`'s Unit tests step now runs `pytest --cov=agent --cov-report=term-missing --cov-fail-under=90 tests/` instead of `python -m unittest discover -v`. Added a `pip install -r requirements.txt` step (none existed before — `requirements.txt` was previously just a header comment). `pytest-cov` added to `requirements.txt`. Verified locally: 48 tests pass, 98.20% statement coverage — 90% floor is a deliberate safety margin below that baseline.
- **Self-hosted-runner token scope review:** Read `agent/poll_once.py` (the script `fixer.yml` runs on the self-hosted Windows runner) end-to-end. It only issues a single `GET /repos/{owner}/{repo}/issues` call — no `gh issue create`/`comment` or any write-scoped API call. `fixer.yml`'s `issues: read` is therefore already correctly minimal; no escalation needed. `runner-health.yml`'s `issues: write` is used for its stated purpose (creating/commenting on a runner-offline issue) and is already correctly scoped. No permission changes made to either file.
- **NO-AZURE deploy lock check:** ci-autopilot has no Azure-deploy workflow (`pages.yml` deploys to GitHub Pages only) — the operator lock requiring `workflow_dispatch`-gating on Azure-deploy workflows does not apply to this repo.

## Test plan

- [x] `grep -c "uses: [a-z/-]*@v[0-9]"` returns 0 for all 4 remediated files (no unpinned tag-only refs remain)
- [x] `pytest --cov=agent --cov-fail-under=90 tests/` exits 0 locally (48 passed, 98.20% coverage)
- [x] `scripts/workflow-lint.ps1 -Path portfolio/ci-autopilot -Json` reports clean against this branch
- [x] Not merged — PR opened for review only

🤖 Generated with GSD plan executor (Phase 31-05)