### PR TITLE
fix(health): separate monitored runner identity

### DIFF
--- a/.github/workflows/runner-health.yml
+++ b/.github/workflows/runner-health.yml
@@ -76,9 +76,9 @@ jobs:
           server_port: ${{ env.SMTP_PORT }}
           username: ${{ env.SMTP_USERNAME }}
           password: ${{ env.SMTP_PASSWORD }}
-          subject: "Runner offline: MyLocalPC"
+          subject: "Runner offline: ${{ env.MONITORED_RUNNER_NAME }}"
           body: |
-            Runner: MyLocalPC
+            Runner: ${{ env.MONITORED_RUNNER_NAME }}
             Repo: ${{ github.repository }}
             Status: ${{ steps.status.outputs.runner_status }}
           to: ${{ env.EMAIL_TO }}

--- a/.github/workflows/runner-health.yml
+++ b/.github/workflows/runner-health.yml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 15
     env:
       GH_TOKEN: ${{ secrets.RUNNER_PAT || github.token }}
-      RUNNER_NAME: MyLocalPC
+      MONITORED_RUNNER_NAME: CAS-Workstation-Kim
       EMAIL_TO: ${{ secrets.EMAIL_TO }}
     steps:
       - name: Check runner status
@@ -24,7 +24,7 @@ jobs:
         run: |
           set -euo pipefail
           status=""
-          if ! status="$(gh api repos/${GITHUB_REPOSITORY}/actions/runners --jq ".runners[] | select(.name==\"${RUNNER_NAME}\") | .status")"; then
+          if ! status="$(gh api repos/${GITHUB_REPOSITORY}/actions/runners --jq ".runners[] | select(.name==\"${MONITORED_RUNNER_NAME}\") | .status")"; then
             status="unknown"
           fi
           if [ -z "${status}" ]; then
@@ -36,7 +36,7 @@ jobs:
         if: steps.status.outputs.runner_status != 'online'
         run: |
           set -euo pipefail
-          title="Runner offline: ${RUNNER_NAME}"
+          title="Runner offline: ${MONITORED_RUNNER_NAME}"
           marker="Autopilot Runner Health"
           status="${{ steps.status.outputs.runner_status }}"
           gh label create runner-offline --color "B60205" --description "Runner offline alerts" --force --repo "${GITHUB_REPOSITORY}" || true
@@ -44,7 +44,7 @@ jobs:
           body=$(cat <<EOF
           ${marker}
 
-          Runner: ${RUNNER_NAME}
+          Runner: ${MONITORED_RUNNER_NAME}
           Status: ${status}
           Repo: ${GITHUB_REPOSITORY}
           Time: $(date -u +"%Y-%m-%dT%H:%M:%SZ")

--- a/memory/examples/20260710_runner-health-reserved-variable.md
+++ b/memory/examples/20260710_runner-health-reserved-variable.md
@@ -1,0 +1,8 @@
+# Runner health target variable
+
+Issue Description: Runner Health Monitor created alerts for its GitHub-hosted monitor instead of the intended self-hosted runner.
+State: The workflow defined `RUNNER_NAME`, which GitHub Actions reserves for the executing runner and overwrote at runtime.
+Action: Renamed the target variable to `MONITORED_RUNNER_NAME` and added a regression test for the workflow contract.
+Result: Health checks now query and report the configured self-hosted runner name.
+Diff Patch: Updated `.github/workflows/runner-health.yml` and added `tests/test_runner_health_workflow.py`.
+Rationale: Workflow environment variables must not collide with GitHub Actions built-ins.

--- a/tests/test_runner_health_workflow.py
+++ b/tests/test_runner_health_workflow.py
@@ -7,3 +7,5 @@ def test_runner_health_uses_non_reserved_target_name() -> None:
     assert "MONITORED_RUNNER_NAME: CAS-Workstation-Kim" in workflow
     assert "${MONITORED_RUNNER_NAME}" in workflow
     assert "RUNNER_NAME: MyLocalPC" not in workflow
+    assert 'subject: "Runner offline: ${{ env.MONITORED_RUNNER_NAME }}"' in workflow
+    assert "Runner: ${{ env.MONITORED_RUNNER_NAME }}" in workflow

--- a/tests/test_runner_health_workflow.py
+++ b/tests/test_runner_health_workflow.py
@@ -1,0 +1,9 @@
+from pathlib import Path
+
+
+def test_runner_health_uses_non_reserved_target_name() -> None:
+    workflow = Path(".github/workflows/runner-health.yml").read_text(encoding="utf-8")
+
+    assert "MONITORED_RUNNER_NAME: CAS-Workstation-Kim" in workflow
+    assert "${MONITORED_RUNNER_NAME}" in workflow
+    assert "RUNNER_NAME: MyLocalPC" not in workflow


### PR DESCRIPTION
## Summary
Correct Runner Health Monitor so it observes the intended self-hosted runner instead of GitHub Actions built-in runtime metadata.

## Changes
- Rename the monitored-runner environment variable to avoid the reserved `RUNNER_NAME`.
- Set the target to the restored `CAS-Workstation-Kim` runner.
- Add a workflow contract regression test and documented fix record.

## Why
GitHub Actions overwrote `RUNNER_NAME` in the health monitor, causing false offline alerts for hosted runners.

## Validation
- Executed the new workflow contract test directly.
- Parsed `runner-health.yml` with PyYAML.
- Ran `git diff --check`.

## Risks
Existing stale alerts remain historical evidence; a post-merge dispatch verifies only future monitoring.

## Related
Addresses false alerts such as #2268.

## Reviewer notes
Review the variable rename in `.github/workflows/runner-health.yml` first.