### PR TITLE
fix(ci): repin release-please reusable workflow to reachable SHA

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -10,4 +10,4 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
-    uses: Coding-Autopilot-System/.github/.github/workflows/release-please-reusable.yml@f288e5e3b67b29a2c08880b76da7b852f4a132d0
+    uses: Coding-Autopilot-System/.github/.github/workflows/release-please-reusable.yml@64c1673088ff7802f1270a44f03bc4d7a10631f2


### PR DESCRIPTION
## Root cause

The .github/workflows/release-please.yml reusable-workflow call was pinned
to f288e5e3b67b29a2c08880b76da7b852f4a132d0 - a commit that only ever
existed at the tip of a PR branch in Coding-Autopilot-System/.github
(PR #16). When that PR was squash-merged, the source branch was deleted and
the branch-tip commit became unreachable (it was never on main). Every
push-triggered release-please run since has failed with
"workflow was not found".

## Fix

Repin to 64c1673088ff7802f1270a44f03bc4d7a10631f2, the merged commit on
Coding-Autopilot-System/.github's main branch that contains
.github/workflows/release-please-reusable.yml. Verified reachable via:

- gh api repos/Coding-Autopilot-System/.github/commits/64c1673088ff7802f1270a44f03bc4d7a10631f2 resolves
- gh api .../compare/main...64c1673088ff7802f1270a44f03bc4d7a10631f2 returns "identical" (this SHA IS main HEAD)
- .github/workflows/release-please-reusable.yml exists at that SHA

This unbreaks the failed release-please runs for this repo.

## Merge note

Out-of-class for auto-merge (workflow file change) - operator merge required.
