### PR TITLE
fix(ci): wire release-please PAT into release workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -10,4 +10,6 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
-    uses: Coding-Autopilot-System/.github/.github/workflows/release-please-reusable.yml@64c1673088ff7802f1270a44f03bc4d7a10631f2
+    uses: Coding-Autopilot-System/.github/.github/workflows/release-please-reusable.yml@320a99a4c15487786dc73827ba7416303ab3fd1b
+    secrets:
+      release-please-token: ${{ secrets.RELEASE_PLEASE_TOKEN }}


### PR DESCRIPTION
## Summary
Update the release-please caller workflow to use the merged org reusable workflow commit and pass `RELEASE_PLEASE_TOKEN` explicitly.

## Changes
- pin the reusable workflow call to `.github` commit `320a99a4c15487786dc73827ba7416303ab3fd1b`
- pass `secrets.RELEASE_PLEASE_TOKEN` into the reusable workflow

## Why
GitHub Actions on these repos cannot create release PRs with the default token alone. The reusable workflow now supports an explicit PAT fallback, so the caller must pass it.

## Validation
- compared the live default-branch workflow against the prepared local workflow
- verified repo-level `RELEASE_PLEASE_TOKEN` exists before opening this PR
- verified the canary rollout succeeded on the same reusable workflow SHA

## Risks
This changes the release automation path on the default branch. The expected follow-up signal is a fresh `Release Please` workflow run after merge.

## Related
Follows `.github` PR #24 and the successful canary rollout in `autogen` and `gsd-orchestrator`.

## Reviewer notes
Start with `.github/workflows/release-please.yml`; the change is intentionally limited to one workflow file.
